### PR TITLE
Add nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,6 +1,17 @@
 name: Nighly Build
 
 on:
+  workflow_dispatch:
   schedule:
   # every day at 2AM
   - cron: "0 2 * * *"
+
+
+jobs:
+   build-haystack-home:
+     runs-on: ubuntu-latest
+
+     steps:
+       - name: trigger-hook
+         run: |
+           curl -X POST ${{ secrets.VERCEL_DEPLOY_HOOK }}


### PR DESCRIPTION
- Build the website every day at 2AM
- The nightly workflow can also be triggered manually from Github UI

Blocked on https://github.com/deepset-ai/haystack-home/pull/25