### PR TITLE
permanently redirecting all versioned tutorials here

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -88,6 +88,11 @@
       "source":"/benchmarks/v:version",
       "destination":"/benchmarks",
       "permanent": false
+    },
+    {
+      "source":"/tutorials/v:version/:name",
+      "destination":"/tutorials/:name",
+      "permanent": true
     }
   ]
 }


### PR DESCRIPTION
Just noticed versioned tutorials were left out. Best to permanently redirect them? 