### PR TITLE
add option to exclude pages from sitemap

### DIFF
--- a/themes/haystack/layouts/_default/sitemap.xml
+++ b/themes/haystack/layouts/_default/sitemap.xml
@@ -1,7 +1,7 @@
 {{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
-  {{ range .Data.Pages }}
+  {{ range where .Data.Pages "Params.sitemap_exclude" "ne" true }}
     {{- if .Permalink -}}
         <url>
             <loc>{{ .Permalink | replaceRE "/$" "" }}</loc>


### PR DESCRIPTION
Added option to exclude pages from the sitemap by adding `sitemap_exclude: true` to frontmatter.