### PR TITLE
Change colab button location

### DIFF
--- a/themes/haystack/assets/sass/abstracts/_variables.scss
+++ b/themes/haystack/assets/sass/abstracts/_variables.scss
@@ -22,6 +22,7 @@
   --color-dark-grey-rgb: 144, 144, 178;
   --color-blue-rgb: 24, 139, 245;
   --color-dark-blue-rgb: 43, 47, 85;
+  --color-light-blue-rgb:17,129,193;
   --color-green-rgb: 3, 175, 157;
   --color-yellow-rgb: 255, 197, 92;
 

--- a/themes/haystack/assets/sass/components/_buttons.scss
+++ b/themes/haystack/assets/sass/components/_buttons.scss
@@ -113,6 +113,21 @@ button.nav-toggle-close {
     }
   }
 
+  &.btn-light-blue {
+    background-color: rgba($color: #{var(--color-light-blue-rgb)}, $alpha: 1);
+    color: var(--color-white);
+
+    svg {
+      fill: var(--color-white);
+    }
+
+    &:hover {
+      background-color: rgba(
+        $color: #{var(--color-dark-blue-rgb)},
+        $alpha: 0.9
+      );
+    }
+  }
 
   &.btn-grey {
     background-color: rgba($color: #{var(--color-dark-grey-rgb)}, $alpha: 1);

--- a/themes/haystack/layouts/_default/tutorial.html
+++ b/themes/haystack/layouts/_default/tutorial.html
@@ -8,14 +8,17 @@
 
         {{/* Tutorial */}}
         <article class="article-content">
-
+          {{ with .Params.title }}
+            <h1> {{.}} </h1>
+          {{ end }}
+          
           <div class="button-container">
 
             {{/* Colab button */}}
             {{ with .Params.colab }}
               <a
                 href="{{ . }}"
-                class="btn btn-dark-blue colab-btn"
+                class="btn btn-light-blue colab-btn"
                 target="_blank"
                 rel="noopener"
               >
@@ -96,7 +99,7 @@
               {{ . | time.Format ":date_long" }}
             </sub>
           {{ end }}
-
+         
           {{/* Article content */}}
           {{ .Content }}
 

--- a/themes/haystack/layouts/_default/tutorial.html
+++ b/themes/haystack/layouts/_default/tutorial.html
@@ -9,7 +9,8 @@
         {{/* Tutorial */}}
         <article class="article-content">
           {{ with .Params.title }}
-            <h1> {{.}} </h1>
+            <h1> Tutorial: {{.}} </h1>
+            <br>
           {{ end }}
           
           <div class="button-container">


### PR DESCRIPTION
This PR should be merged just before [this PR on Haystack Tutorials](https://github.com/deepset-ai/haystack-tutorials/pull/70) which introduces the download paths, and disregards the first H1 title while generating the `.md` file so that we can do the following which is implemented in this PR:
1. Change the backgrounf color of the 'open in colab' button to the usual blue :)
2. Add the open in colab and download buttons below the title