### PR TITLE
Make inline codes the same size with the regular text

### DIFF
--- a/themes/haystack/assets/sass/components/_article.scss
+++ b/themes/haystack/assets/sass/components/_article.scss
@@ -357,8 +357,3 @@ blockquote {
     margin-top: 0;
   }
 }
-
-// Code blocks
-code {
-  font-size: var(--text-base);
-}

--- a/themes/haystack/assets/sass/components/_code.scss
+++ b/themes/haystack/assets/sass/components/_code.scss
@@ -17,4 +17,8 @@ pre {
   overflow: auto;
   padding: 1rem;
   background-color: var(--color-bg-light-grey) !important;
+
+  code {
+    font-size: var(--text-base);
+  }
 }


### PR DESCRIPTION
* Override the font size of code blocks' code

<img width="806" alt="image" src="https://user-images.githubusercontent.com/25897116/211050317-1761e609-8045-44bd-82da-21a423f05a52.png">
