### PR TITLE
Prevent Haystack home from being embedded in HTML frames

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -21,7 +21,7 @@
           "value" : "DENY"
         }
       ]
-    },
+    }
   ],
 
   "trailingSlash": false,

--- a/vercel.json
+++ b/vercel.json
@@ -6,13 +6,22 @@
         {
           "key": "Cache-Control",
           "value": "public, max-age=31536000, immutable"
-        },
-        {
-          "key": "x-frame-options",
-          "value": "DENY"
         }
       ]
-    }
+    },
+    {
+      "source": "/(.*)",
+      "headers" : [
+        {
+          "key" : "X-Content-Type-Options",
+          "value" : "nosniff"
+        },
+        {
+          "key" : "X-Frame-Options",
+          "value" : "DENY"
+        }
+      ]
+    },
   ],
 
   "trailingSlash": false,

--- a/vercel.json
+++ b/vercel.json
@@ -6,6 +6,10 @@
         {
           "key": "Cache-Control",
           "value": "public, max-age=31536000, immutable"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
         }
       ]
     }

--- a/vercel.json
+++ b/vercel.json
@@ -8,7 +8,7 @@
           "value": "public, max-age=31536000, immutable"
         },
         {
-          "key": "X-Frame-Options",
+          "key": "x-frame-options",
           "value": "DENY"
         }
       ]


### PR DESCRIPTION
Part of a broader security best practices initiative.

To test, try embedding the preview link in a frame - the site should not be shown
```html
<html>
<head></head>

<body>

<iframe width="1000" height="500" src="https://haystack-home-git-masci-patch-1-deepset-overnice.vercel.app/"> </iframe>

</body>
</html>
```

On the contrary, current production version should be shown correctly (and we don't want this to happen)
```html
<html>
<head></head>

<body>

<iframe width="1000" height="500" src="https://haystack.deepset.ai/"> </iframe>

</body>
</html>
```