### PR TITLE
Fetch commit history with the clone

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 rm -rf haystack-tutorials
-git clone --depth 1 https://github.com/deepset-ai/haystack-tutorials.git
+git clone --filter=tree:0 https://github.com/deepset-ai/haystack-tutorials.git
 echo "Copying markdown files into ./content/tutorials..."
 cp ./haystack-tutorials/markdowns/* ./content/tutorials
 ls ./content/tutorials


### PR DESCRIPTION
Fixes #90 🤞 
* `--depth 1` argument truncates the commit history and fetches only the last commit
* `--filter=tree:0` downloads all reachable commits

Source: [Blog Post](https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/#user-content-quick-summary)