### PR TITLE
enable image captions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Second tab content here
 {{< /tabs >}}
 ```
 
+### Adding an image in article content
+
+![alt text](image path.png "Markdown *caption* with a **[bold link](/)**")
+
 ### Editing the theme
 
 HTML template files are located at /themes/haystack/layouts

--- a/content/blog/generative-vs-extractive-models/index.md
+++ b/content/blog/generative-vs-extractive-models/index.md
@@ -3,6 +3,7 @@ layout: blog-post
 title: Generative vs. Extractive Language Models
 description: Which one is right for your use case?
 featured_image: thumbnail.png
+featured_image_caption: Markdown *caption* with a **[bold link](/)**
 images: ["blog/generative-vs-extractive-models/thumbnail.png"]
 toc: True
 date: 2023-05-22
@@ -17,7 +18,7 @@ This sets them apart from their humbler siblings: _extractive_ language models. 
 
 However, extractive models differ from generative models in that they explicitly need a context to extract information from at querying time, and they return that information as direct quotations from the source, whereas generative models are trained for generating language and capable of writing new text from scratch. Compared to the fluency of their generative counterparts, extractive models like RoBERTa and ELECTRA can therefore seem much less capable.
 
-![A comparison of extractive and generative models' responses to the question 'Who was Shakespeare?'. The generative model provides a detailed generated answer, while the extractive model gives a concise response extracted from a text.](shakespeare.png)
+![A comparison of extractive and generative models' responses to the question 'Who was Shakespeare?'. The generative model provides a detailed generated answer, while the extractive model gives a concise response extracted from a text.](shakespeare.png "Markdown *caption* with a **[bold link](/)**")
 
 But it is becoming increasingly clear that generative models suffer from their own set of problems, like their size, the fact that many of them are proprietary (which isn’t ideal for everyone), and most significantly, their tendency to make things up. What’s more, extractive models have a much better track record in real-world applications — for example, in private or public semantic search engines, or in information extraction systems.
 

--- a/content/blog/generative-vs-extractive-models/index.md
+++ b/content/blog/generative-vs-extractive-models/index.md
@@ -3,7 +3,7 @@ layout: blog-post
 title: Generative vs. Extractive Language Models
 description: Which one is right for your use case?
 featured_image: thumbnail.png
-featured_image_caption: Markdown *caption* with a **[bold link](/)**
+featured_image_caption: Used by permission of the Folger Shakespeare Library under a Creative Commons Attribution-ShareAlike 4.0 International License.
 images: ["blog/generative-vs-extractive-models/thumbnail.png"]
 toc: True
 date: 2023-05-22
@@ -18,7 +18,7 @@ This sets them apart from their humbler siblings: _extractive_ language models. 
 
 However, extractive models differ from generative models in that they explicitly need a context to extract information from at querying time, and they return that information as direct quotations from the source, whereas generative models are trained for generating language and capable of writing new text from scratch. Compared to the fluency of their generative counterparts, extractive models like RoBERTa and ELECTRA can therefore seem much less capable.
 
-![A comparison of extractive and generative models' responses to the question 'Who was Shakespeare?'. The generative model provides a detailed generated answer, while the extractive model gives a concise response extracted from a text.](shakespeare.png "Markdown *caption* with a **[bold link](/)**")
+![A comparison of extractive and generative models' responses to the question 'Who was Shakespeare?'. The generative model provides a detailed generated answer, while the extractive model gives a concise response extracted from a text.](shakespeare.png)
 
 But it is becoming increasingly clear that generative models suffer from their own set of problems, like their size, the fact that many of them are proprietary (which isn’t ideal for everyone), and most significantly, their tendency to make things up. What’s more, extractive models have a much better track record in real-world applications — for example, in private or public semantic search engines, or in information extraction systems.
 

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,2 +1,9 @@
-{{/*  Adds lazy loading to images added through markdown  */}}
-<img loading="lazy" src="{{.Destination | safeURL}}" alt="{{.Text}}" /> 
+{{/* Renders images in articles */}}
+{{ if .Title }}
+    <figure>
+        <img loading="lazy" src="{{.Destination | safeURL}}" alt="{{.Text}}" />
+        <figcaption>{{ .Title | markdownify }}</figcaption>
+    </figure>
+{{ else }}
+    <img loading="lazy" src="{{.Destination | safeURL}}" alt="{{.Text}}" />
+{{ end }}

--- a/themes/haystack/assets/sass/components/_article.scss
+++ b/themes/haystack/assets/sass/components/_article.scss
@@ -45,6 +45,14 @@
     gap: 4rem;
   }
 
+  .featured-image-wrapper {
+    width: 100%;
+    @include lg {
+      max-width: 30rem;
+      order: 2;
+    }
+  }
+
   .featured-image {
     border-radius: var(--border-radius-md);
     overflow: hidden;
@@ -53,8 +61,6 @@
 
     @include lg {
       height: 17rem;
-      max-width: 30rem;
-      order: 2;
     }
 
     > img {
@@ -64,6 +70,7 @@
       margin-top: 0;
     }
   }
+
 
   .blog-post-title {
     width: 100%;
@@ -596,5 +603,19 @@ blockquote {
     span {
       font-size: 1rem;
     }
+  }
+}
+
+// Image caption
+figcaption {
+  font-size: var(--text-base);
+  color: var(--color-dark-grey);
+  text-align: center;
+  margin-top: 0.75rem;
+
+  a {
+    font-size: var(--text-base);
+    color: var(--color-dark-grey);
+    text-decoration: underline;
   }
 }

--- a/themes/haystack/layouts/_default/blog-post.html
+++ b/themes/haystack/layouts/_default/blog-post.html
@@ -18,15 +18,22 @@
         <article class="blog-post-content">
           {{/* Blog post header */}}
           <div class="blog-post-header">
-            {{/* Featured image */}}
-            {{ if .Params.featured_image }}
-              <div class="featured-image">
-                <img
-                  src="{{.Permalink}}{{ .Params.featured_image }}"
-                  alt="{{ .Params.alt_image }}"
-                />
-              </div>
-            {{ end }}
+
+            <figure class="featured-image-wrapper">
+              {{/* Featured image */}}
+              {{ if .Params.featured_image }}
+                <div class="featured-image">
+                  <img
+                    src="{{.Permalink}}{{ .Params.featured_image }}"
+                    alt="{{ .Params.alt_image }}"
+                  />
+                </div>
+                
+              {{ end }}
+              {{ if .Params.featured_image_caption}}
+              <figcaption>{{.Params.featured_image_caption | markdownify}}</figcaption>
+              {{ end }}
+            </figure>
 
 
             <div class="blog-post-title">


### PR DESCRIPTION
Enabled image captions for blog images
Usage:
```
![alt text](shakespeare.png "Markdown *caption* with a **[bold link](/)**")
```