### PR TITLE
fix for canonicals with trailing /

### DIFF
--- a/themes/haystack/layouts/partials/head.html
+++ b/themes/haystack/layouts/partials/head.html
@@ -14,9 +14,6 @@
   {{/* Canonical url */}}
   {{ if .Params.canonical_url }}
     <link rel="canonical" href="{{ .Params.canonical_url }}" />
-  {{ else }}
-    <link rel="canonical" href="{{ .Permalink }}" />
-  {{ end }}
 
 
   {{/*  <title>{{ .Title | plainify }} | {{ .Site.Title }}</title>  */}}

--- a/themes/haystack/layouts/partials/head.html
+++ b/themes/haystack/layouts/partials/head.html
@@ -14,6 +14,7 @@
   {{/* Canonical url */}}
   {{ if .Params.canonical_url }}
     <link rel="canonical" href="{{ .Params.canonical_url }}" />
+  {{ end }}
 
 
   {{/*  <title>{{ .Title | plainify }} | {{ .Site.Title }}</title>  */}}


### PR DESCRIPTION
Hey @carlosgauci do you think this change would be ok?
We have an issue in terms of technical SEO in that we get these reported. Showing that the canoncial url for pages is different to what there is in the sitemap. So I did this which would mean that only if there's a `canonical_url` mentioned then we add the meta. If not we skip.

<img width="1575" alt="image" src="https://github.com/deepset-ai/haystack-home/assets/15802862/b4495908-068f-4684-9e79-cb1b8b5bce2a">
