### PR TITLE
Hidden pages

### DIFF
--- a/themes/haystack/layouts/_default/integrations.html
+++ b/themes/haystack/layouts/_default/integrations.html
@@ -1,16 +1,18 @@
 {{/* Integrations page */}}
 {{ define "main" }}
+  {{ $integrations := where .Data.Pages "Params.hidden" "!=" true }}
+
   <div class="grid-page">
     {{/* Hero */}}
     {{ partial "page-hero" . }}
 
-
     <div class="grid-page-content">
       <div class="container container-padded">
         <div class="inner inner-top">
+
           {{/* Section title */}}
           <h2 class="section-title">
-            {{ len (where .Site.Pages "Layout" "integration") }} Total
+            {{ len $integrations }} Total
             Integrations
           </h2>
 
@@ -54,7 +56,7 @@
                   <option value="all">All Types</option>
 
                   {{ $types := slice }}
-                  {{ range where .Site.Pages "Layout" "integration" }}
+                  {{ range $integrations }}
                     {{ if .Params.type }}
                       {{ if not (in $types .Params.type) }}
                         {{ $types = $types | append .Params.type }}
@@ -80,7 +82,7 @@
 
           {{/* Integrations grid */}}
           <div class="grid-page-grid integrations-grid">
-            {{ range where .Site.Pages "Layout" "integration" }}
+            {{ range $integrations }}
               {{ partial "integration-card" . }}
             {{ end }}
           </div>

--- a/themes/haystack/layouts/_default/tutorials.html
+++ b/themes/haystack/layouts/_default/tutorials.html
@@ -1,5 +1,6 @@
 {{/* Tutorials page */}}
 {{ define "main" }}
+  {{ $tutorials := where .Data.Pages "Params.hidden" "!=" true }}
   <div class="grid-page">
     {{/* Hero */}}
     {{ partial "page-hero" . }}
@@ -9,7 +10,7 @@
         <div class="inner inner-top">
           {{/* Section title */}}
           <h2 class="section-title">
-            {{ len (where .Site.Pages "Layout" "tutorial") }} tutorials for
+            {{ len $tutorials }} tutorials for
             <span>all</span> levels
           </h2>
 
@@ -92,13 +93,16 @@
 
           {{/* Tutorials grid */}}
           <div class="grid-page-grid">
+            {{ $featured := where $tutorials "Params.featured" true }}
+            {{ $notFeatured := where $tutorials "Params.featured" "!=" true }}
+
             {{/*  Featured tutorials  */}}
-            {{ range where (where .Site.Pages "Params.featured" true) "Layout" "tutorial" }}
+            {{ range $featured }}
               {{ partial "tutorial-card" . }}
             {{ end }}
 
             {{/*  Other tutorials  */}}
-            {{ range where (where .Site.Pages "Params.featured" "!=" true) "Layout" "tutorial" }}
+            {{ range $notFeatured }}
               {{ partial "tutorial-card" . }}
             {{ end }}
           </div>

--- a/themes/haystack/layouts/partials/blog-list.html
+++ b/themes/haystack/layouts/partials/blog-list.html
@@ -4,6 +4,7 @@
   {{ $title = .Params.title }}
 {{end}}
 
+{{ $blogPosts := where .Data.Pages "Params.hidden" "!=" true }}
 
 <div class="blog-list-content">
   <div class="container container-padded">
@@ -74,7 +75,7 @@
 
       <div class="blog-grid-container">
         {{ $currentTags := slice }}
-        {{ range .Data.Pages }}
+        {{ range $blogPosts }}
           {{ $currentTags = union $currentTags .Params.tags }}
         {{ end }}
         {{ $currentTags = sort $currentTags }}
@@ -108,9 +109,6 @@
         {{ end }}
         {{/* Blog posts grid */}}
         <div class="blog-grid blog-grid-static">
-          {{/* Get the blog posts */}}
-          {{ $blogPosts := .Data.Pages }}
-  
           {{/* Append homepage to blogposts and hide it later - hack to get 1 less post on the first page, to show a
           larger featured post */}}
           {{ if not (or (eq .Type "authors") (eq .Type "tags")) }}

--- a/themes/haystack/layouts/partials/integration-sidebar.html
+++ b/themes/haystack/layouts/partials/integration-sidebar.html
@@ -3,10 +3,11 @@
   <div class="accordions">
     <span class="sidebar-title">Integrations</span>
     {{ $currentPage := . }}
+    {{ $integrations := where (.GetPage "/integrations").Pages "Params.hidden" "!=" true }}
 
     {{/*  Get all the integration types  */}}
     {{ $types := slice }}
-    {{ range where .Site.Pages "Layout" "integration" }}
+    {{ range $integrations }}
       {{ if .Params.type }}
         {{ if not (in $types .Params.type) }}
           {{ $types = $types | append .Params.type }}
@@ -25,7 +26,7 @@
         </summary>
 
         <ul class="content" role="list">
-          {{ range where (where $.Site.Pages "Section" "integrations")  ".Params.type" . }}
+          {{ range where $integrations ".Params.type" . }}
             <li>
               {{ if (eq $currentPage.RelPermalink .RelPermalink) }}
                 <p>{{ .Params.name }}</p>

--- a/themes/haystack/layouts/partials/tutorial-sidebar.html
+++ b/themes/haystack/layouts/partials/tutorial-sidebar.html
@@ -2,6 +2,8 @@
 <aside class="toc-sidebar">
   <div class="accordions">
     {{ $currentPage := . }}
+    {{ $tutorials := where  (.GetPage "/tutorials").Pages "Params.hidden" "!=" true }}
+
     {{/* Beginner */}}
     <details
       class="accordion-js"
@@ -11,7 +13,7 @@
         <div class="accordion-title-child">Beginner</div>
       </summary>
       <ul class="content" role="list">
-        {{ range where (where .Site.Pages "Section" "tutorials")  ".Params.level" "beginner" }}
+        {{ range where $tutorials ".Params.level" "beginner" }}
           <li>
             {{ if (eq $currentPage.RelPermalink .RelPermalink) }}
               <details class="accordion-js accordion-child" open>
@@ -45,7 +47,7 @@
         <div class="accordion-title-child">Intermediate</div>
       </summary>
       <ul class="content" role="list">
-        {{ range where (where .Site.Pages "Section" "tutorials")  ".Params.level" "intermediate" }}
+        {{ range where $tutorials ".Params.level" "intermediate" }}
           <li>
             {{ if (eq $currentPage.RelPermalink .RelPermalink) }}
               <details class="accordion-js accordion-child" open>
@@ -79,7 +81,7 @@
         <div class="accordion-title-child">Advanced</div>
       </summary>
       <ul class="content" role="list">
-        {{ range where (where .Site.Pages "Section" "tutorials")  ".Params.level" "advanced" }}
+        {{ range where $tutorials ".Params.level" "advanced" }}
           <li>
             {{ if (eq $currentPage.RelPermalink .RelPermalink) }}
               <details class="accordion-js accordion-child" open>


### PR DESCRIPTION
Enables the hiding of blog posts, integrations and tutorials from their listing page and sidebars, when `hidden: true` is set on the frontmatter