### PR TITLE
Add TOC for integrations page

### DIFF
--- a/themes/haystack/layouts/partials/integration-sidebar.html
+++ b/themes/haystack/layouts/partials/integration-sidebar.html
@@ -29,7 +29,15 @@
           {{ range where $integrations ".Params.type" . }}
             <li>
               {{ if (eq $currentPage.RelPermalink .RelPermalink) }}
-                <p>{{ .Params.name }}</p>
+              <details class="accordion-js accordion-child" open>
+                <summary class="accordion-title">{{ .Params.name }}</summary>
+                {{if .Params.toc}}
+                  <div class="content">
+                    {{/* Page TOC */}}
+                    {{ .TableOfContents }}
+                  </div>
+                {{ end }}
+              </details>
               {{ else }}
                 <a
                   class="tutorial-card category-{{ lower .Params.category }}"


### PR DESCRIPTION
Add ToC section for integration. We need to add `toc: true` to the frontmatter of integration pages for this to work

# Before:

![image](https://github.com/deepset-ai/haystack-home/assets/25897116/41273922-9774-49c9-8e21-b7f248e09c44)

# After:
![image](https://github.com/deepset-ai/haystack-home/assets/25897116/8d1f26e6-8b51-4ed4-b98d-2e74ff6aa19b)