### PR TITLE
Extend print statement in quick start code

### DIFF
--- a/content/overview/quick-start.md
+++ b/content/overview/quick-start.md
@@ -41,14 +41,16 @@ pip install haystack-ai
 import os
 from haystack import Pipeline, PredefinedPipeline
 
-os.environ["OPENAI_API_KEY"] = "Your OpenAI API Key"
+os.environ["OPENAI_API_KEY"] = "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"
 
 pipeline = Pipeline.from_template(PredefinedPipeline.CHAT_WITH_WEBSITE)
+query = "How should I install Haystack?"
 result = pipeline.run({
     "fetcher": {"urls": ["https://haystack.deepset.ai/overview/quick-start"]},
-    "prompt": {"query": "How should I install Haystack?"}}
+    "prompt": {"query": query}}
 )
-print(result["llm"]["replies"][0])
+answer = result["llm"]["replies"][0]
+print(f"Query: {query}\nAnswer: {answer}")
 ```
 {{< /tab  >}}
 


### PR DESCRIPTION
Currently, the pipeline just prints:
```
To install Haystack, you can use the following command:

pip install haystack-ai
```
After the changes it prints:
```
Query: How should I install Haystack?
Answer: To install Haystack, you can use the following command: pip install haystack-ai.
```
This should help users better understand that the output is an answer to the query and not an error message. We had users who thought that the example wasn't working because Haystack wasn't installed correctly.