### PR TITLE
Extend print in quick start example

### DIFF
--- a/content/overview/quick-start.md
+++ b/content/overview/quick-start.md
@@ -44,11 +44,13 @@ from haystack import Pipeline, PredefinedPipeline
 os.environ["OPENAI_API_KEY"] = "Your OpenAI API Key"
 
 pipeline = Pipeline.from_template(PredefinedPipeline.CHAT_WITH_WEBSITE)
+query = "How should I install Haystack?"
 result = pipeline.run({
     "fetcher": {"urls": ["https://haystack.deepset.ai/overview/quick-start"]},
-    "prompt": {"query": "How should I install Haystack?"}}
+    "prompt": {"query": query}}
 )
-print(result["llm"]["replies"][0])
+answer = result["llm"]["replies"][0]
+print(f"Query: {query}\nAnswer: {answer}")
 ```
 {{< /tab  >}}
 


### PR DESCRIPTION
Currently the output of the example is just:
```
To install Haystack, you can use the following command: pip install haystack-ai.
```

After this change the output is:
```
Query: How should I install Haystack?
Answer: To install Haystack, you can use the following command: pip install haystack-ai.
```

This change should help users to better understand that the output is no error message but the answer to a query. We had users who thought it is an error message and thought they didn't install Haystack correctly.