### PR TITLE
migrate to HF API components

### DIFF
--- a/content/blog/level-up-rag-with-speaker-diarization/index.md
+++ b/content/blog/level-up-rag-with-speaker-diarization/index.md
@@ -182,11 +182,11 @@ Next, it is time to set up the retrieval augmentation (RAG) pipeline for speaker
 * [`SentenceTransformersTextEmbedder`](https://docs.haystack.deepset.ai/docs/sentencetransformerstextembedder): To create an embedding for the user query using sentence-transformers models
 * [`InMemoryEmbeddingRetriever`](https://docs.haystack.deepset.ai/docs/inmemoryembeddingretriever): to retrieve `top_k` relevant documents to the user query
 * [`PromptBuilder`](https://docs.haystack.deepset.ai/docs/promptbuilder): to provide a RAG prompt template with instructions to be filled with retrieved documents and the user query
-* [`HuggingFaceTGIGenerator`](https://docs.haystack.deepset.ai/docs/huggingfacetgigenerator): to infer models served through Hugging Face free Inference API or Hugging Face TGI
+* [`HuggingFaceAPIGenerator`](https://docs.haystack.deepset.ai/docs/huggingfaceapigenerator): to infer models served through Hugging Face free Serverless Inference API or Hugging Face TGI
 
 ```python
 from haystack.components.builders.prompt_builder import PromptBuilder
-from haystack.components.generators import HuggingFaceTGIGenerator
+from haystack.components.generators import HuggingFaceAPIGenerator
 from haystack.components.embedders import SentenceTransformersTextEmbedder
 from haystack.components.retrievers.in_memory import InMemoryEmbeddingRetriever
 from haystack.utils import ComponentDevice
@@ -206,7 +206,10 @@ GPT4 Correct Assistant:
 
 retriever = InMemoryEmbeddingRetriever(speaker_document_store)
 text_embedder = SentenceTransformersTextEmbedder(device=ComponentDevice.from_str("cuda:0"))
-answer_generator = HuggingFaceTGIGenerator("openchat/openchat-3.5-0106", generation_kwargs={"max_new_tokens":500})
+answer_generator = HuggingFaceAPIGenerator(
+    api_type="serverless_inference_api",
+    api_params={"model": "openchat/openchat-3.5-0106"},
+    generation_kwargs={"max_new_tokens":500})
 prompt_builder = PromptBuilder(template=open_chat_prompt)
 ```
 

--- a/content/blog/using-jina-embeddings-haystack/index.md
+++ b/content/blog/using-jina-embeddings-haystack/index.md
@@ -18,7 +18,7 @@ cookbook: jina-embeddings-v2-legal-analysis-rag.ipynb
 
 With the [Jina Haystack extension](https://haystack.deepset.ai/integrations/jina), you can now take advantage of these new text embedders in your Haystack pipelines! In this post, we'll show what's cool about Jina Embeddings v2 and how to use them.
 
-> You can follow along in the accompanying [Colab notebook of a RAG pipeline that uses the Jina Haystack extension](https://colab.research.google.com/drive/1l8GbQhqxnWXkdktgJfs9Rz4EAtNbHK_L#scrollTo=_coq_qCuItbN).
+> You can follow along in the accompanying [Colab notebook of a RAG pipeline that uses the Jina Haystack extension](https://colab.research.google.com/github/deepset-ai/haystack-cookbook/blob/main/notebooks/jina-embeddings-v2-legal-analysis-rag.ipynb).
 
 ## Advantages of Jina Embeddings v2
 
@@ -126,13 +126,15 @@ indexing_pipeline.run(data={"fetcher": {"urls": urls}})
 
 ## Building the query pipeline
 
-Now the real fun begins. Let's create a query pipeline so we can actually start asking questions. We write a prompt allowing us to pass our documents to the Mixtral-8x7B LLM. Then we initiatialize the LLM via the `HuggingFaceTGIGenerator`.
+Now the real fun begins. Let's create a query pipeline so we can actually start asking questions. We write a prompt allowing us to pass our documents to the Mixtral-8x7B LLM. Then we initiatialize the LLM via the `HuggingFaceAPIGenerator`.
+
+To use this model, you need to accept the conditions here: https://huggingface.co/mistralai/Mixtral-8x7B-Instruct-v0.1
 
 In Haystack 2.0 `retriever`s are tightly coupled to `DocumentStores`. If we pass the document store in the `retriever` we initialized earlier, this pipeline can access those embeddings we generated, and pass them to the LLM.
 
 ```python
 
-from haystack.components.generators import HuggingFaceTGIGenerator
+from haystack.components.generators import HuggingFaceAPIGenerator
 from haystack.components.builders.prompt_builder import PromptBuilder
 
 from jina_haystack.text_embedder import JinaTextEmbedder
@@ -148,8 +150,9 @@ question: {{question}}
 """
 
 text_embedder = JinaTextEmbedder(model="jina-embeddings-v2-base-en")
-generator = HuggingFaceTGIGenerator("mistralai/Mixtral-8x7B-Instruct-v0.1")
-generator.warm_up()
+generator = HuggingFaceAPIGenerator(
+    api_type="serverless_inference_api",
+    api_params={"model": "mistralai/Mixtral-8x7B-Instruct-v0.1"})  
 
 prompt_builder = PromptBuilder(template=prompt)
 query_pipeline = Pipeline()


### PR DESCRIPTION
- part of https://github.com/deepset-ai/haystack/issues/7500
- I'm also updating the cookbook in https://github.com/deepset-ai/haystack-cookbook/pull/83

I replaced HF TGI Generator (deprecated) with HF API Generator.

I left some old articles (without accompanying notebook) unchanged.

