### PR TITLE
chore: Add trafilatura to pip install in quick start code

### DIFF
--- a/content/overview/quick-start.md
+++ b/content/overview/quick-start.md
@@ -55,7 +55,7 @@ print(result["llm"]["replies"][0])
 {{< tab tabName="Corresponding Pipeline"  >}}
 First, install Haystack:
 ```bash
-pip install haystack-ai
+pip install haystack-ai trafilatura
 ```
 
 ```python


### PR DESCRIPTION
pip install command of the "Ask Questions to a Webpage" quick start code example was missing trafilatura, which is required for HTMLToDocument component. This PR adds trafilatura to the pip install command.