### PR TITLE
Update 2.7.0.md release notes

### DIFF
--- a/content/release-notes/2.7.0.md
+++ b/content/release-notes/2.7.0.md
@@ -36,7 +36,7 @@ tracing.enable_tracing(LoggingTracer())
 ![image](https://github.com/user-attachments/assets/08788542-2b08-42d0-812b-391b001f2479)
 
 
-### ⬆️ Upgrade Notes
+## ⬆️ Upgrade Notes
 
 - Removed `Pipeline` init argument `debug_path`. We do not support this anymore.
 


### PR DESCRIPTION
I wanted to link to breaking change notes (Upgrade notes) directly and noticed it wasn't possible for this release because of wrong formatting