### PR TITLE
Tutorial redirects after 1.x EOL

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ rm -rf haystack-tutorials
 # history, like creation date and last modified date of a notebook.
 # If we fetch we depth 1 we don't get correct dates, and if we fetch with
 # --filter=tree:0 the process runs slower than cloning the whole repo.
-git clone https://github.com/deepset-ai/haystack-tutorials.git
+git clone --single-branch --branch 1.x-eol https://github.com/deepset-ai/haystack-tutorials.git
 
 cd haystack-tutorials
 echo "Installing requirements for haystack-tutorials..."

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ rm -rf haystack-tutorials
 # history, like creation date and last modified date of a notebook.
 # If we fetch we depth 1 we don't get correct dates, and if we fetch with
 # --filter=tree:0 the process runs slower than cloning the whole repo.
-git clone --single-branch --branch 1.x-eol https://github.com/deepset-ai/haystack-tutorials.git
+git clone https://github.com/deepset-ai/haystack-tutorials.git
 
 cd haystack-tutorials
 echo "Installing requirements for haystack-tutorials..."

--- a/themes/haystack/layouts/partials/guide-card.html
+++ b/themes/haystack/layouts/partials/guide-card.html
@@ -1,4 +1,4 @@
-<a href="{{ .RelPermalink }}" class="grid-page-card guide-card" {{with .Params.guide}}data-guide="{{.}}"{{end}} {{with .Params.haystack_2}}data-haystack_2="{{.}}"{{end}}>
+<a href="{{ .RelPermalink }}" class="grid-page-card guide-card" {{with .Params.guide}}data-guide="{{.}}"{{end}}>
     {{/*  Header / tags  */}}
     <div class="grid-page-card-header">
 

--- a/themes/haystack/layouts/partials/tutorial-card.html
+++ b/themes/haystack/layouts/partials/tutorial-card.html
@@ -1,4 +1,4 @@
-<a href="{{ .RelPermalink }}" class="grid-page-card" data-level="{{ .Params.level }}" data-created="{{ .Params.created_at }}" data-updated='{{ with .Lastmod }}{{ . | time.Format "2006-01-02" }}{{else}}{{ .Params.created_at }}{{ end }}' {{with .Params.featured}}data-featured="{{.}}"{{end}} {{with .Params.haystack_2}}data-haystack_2="{{.}}"{{end}}>
+<a href="{{ .RelPermalink }}" class="grid-page-card" data-level="{{ .Params.level }}" data-created="{{ .Params.created_at }}" data-updated='{{ with .Lastmod }}{{ . | time.Format "2006-01-02" }}{{else}}{{ .Params.created_at }}{{ end }}' {{with .Params.featured}}data-featured="{{.}}"{{end}}>
     {{/*  Header / tags  */}}
     <div class="grid-page-card-header">
 

--- a/themes/haystack/layouts/partials/tutorial-sidebar.html
+++ b/themes/haystack/layouts/partials/tutorial-sidebar.html
@@ -2,7 +2,7 @@
 <aside class="toc-sidebar {{if .Params.guide}} blog-post-sidebar {{ end }}">
   <div class="accordions">
     {{ $currentPage := . }}
-    {{ $tutorials := where (where (.GetPage "/tutorials").Pages "Params.hidden" "!=" true) "Params.haystack_2" true }}
+    {{ $tutorials := where (.GetPage "/tutorials").Pages "Params.hidden" "!=" true }}
     {{/* Toc */}}
     {{if .Params.guide}}
       <span class="toc-heading">Table of contents</span>

--- a/vercel.json
+++ b/vercel.json
@@ -146,6 +146,46 @@
       "source": "/tutorials/(02_finetune_a_model_on_your_data|09_dpr_training|10_knowledge_graph|15_tableqa|16_document_classifier_at_index_time|17_audio|18_gpl|19_text_to_image_search_pipeline_with_multimodal_retriever|20_using_haystack_with_rest_api|25_customizing_agent)",
       "destination": "/tutorials",
       "permanent": true
+    },
+    {
+      "source": "/tutorials/(01_basic_qa_pipeline|03_scalable_qa_system|04_faq_style_qa|06_better_retrieval_via_embedding_retrieval|07_rag_generator|11_pipelines|12_lfqa|13_question_generation|21_customizing_promptnode|22_pipeline_with_promptnode)",
+      "destination": "/tutorials/27_first_rag_pipeline",
+      "permanent": true
+    },
+    {
+      "source": "/tutorials/08_preprocessing",
+      "destination": "/tutorials/30_file_type_preprocessing_index_pipeline",
+      "permanent": true
+    },
+    {
+      "source": "/tutorials/14_query_classifier",
+      "destination": "/tutorials/32_classifying_documents_and_queries_by_language",
+      "permanent": true
+    },
+    {
+      "source": "/tutorials/26_hybrid_retrieval",
+      "destination": "/tutorials/33_hybrid_retrieval",
+      "permanent": true
+    },
+    {
+      "source": "/tutorials/05_evaluation",
+      "destination": "/tutorials/35_evaluating_rag_pipelines",
+      "permanent": true
+    },
+    {
+      "source": "/tutorials/24_building_chat_app",
+      "destination": "/tutorials/40_building_chat_application_with_function_calling",
+      "permanent": true
+    },
+    {
+      "source": "/tutorials/14_query_classifier",
+      "destination": "/tutorials/41_query_classification_with_transformerstextrouter_and_transformerszeroshottextrouter",
+      "permanent": true
+    },
+    {
+      "source": "/tutorials/23_answering_multihop_questions_with_agents",
+      "destination": "/tutorials/43_building_a_tool_calling_agent",
+      "permanent": true
     }
   ],
 

--- a/vercel.json
+++ b/vercel.json
@@ -141,6 +141,11 @@
       "source": "/cookbook/rag_eval_harness",
       "destination": "/cookbook",
       "permanent": true
+    },
+    {
+      "source": "/tutorials/(02_finetune_a_model_on_your_data|09_dpr_training|10_knowledge_graph|15_tableqa|16_document_classifier_at_index_time|17_audio|18_gpl|19_text_to_image_search_pipeline_with_multimodal_retriever|20_using_haystack_with_rest_api|25_customizing_agent)",
+      "destination": "/tutorials",
+      "permanent": true
     }
   ],
 


### PR DESCRIPTION
Fixes https://github.com/deepset-ai/haystack/issues/8920

* If there's a 1-1 mapping, use the corresponding tutorial to redirect
* Else redirect to Tutorial overview page 
* Redirect most tutorials to https://haystack.deepset.ai/tutorials/27_first_rag_pipeline as it covers most cases