### PR TITLE
Add draft for llms.txt

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -31,6 +31,14 @@ paginatePath = "/"
   [security.funcs]
     getenv = ["^HUGO_", "GOOGLE_TAG_ANALYTICS", "DC_API_KEY", "DC_WORKSPACE_NAME", "DC_PIPELINE_NAME"]
 
+[outputFormats.TXT]
+  mediaType = "text/plain"
+  baseName = "llms"
+  isPlainText = true
+
+[outputs]
+  home = ["HTML", "RSS", "TXT"]
+
 [markup]
   # Code blocks
   [markup.highlight]

--- a/layouts/_default/index.txt
+++ b/layouts/_default/index.txt
@@ -1,0 +1,10 @@
+# {{ .Site.Title }}
+
+> {{ .Site.Params.description }}
+
+## Content
+{{ range $type := .Site.Params.front_page_content }}
+### {{ title $type }}
+
+{{ range (where $.Site.RegularPages "Type" $type) }}- [{{ .Title }}]({{ .Permalink }}index.md): Published {{ .Date.Format "2006-01-02" }}
+{{ end }}{{ end }}

--- a/layouts/_default/index.txt
+++ b/layouts/_default/index.txt
@@ -13,8 +13,7 @@ Installation of integrations: `pip install <provider>-haystack`, for example `pi
 
 ## Docs
 - [Concepts Overview](https://docs.haystack.deepset.ai/docs/components_overview): Brief introduction to the most important concepts, including Components, Pipelines, Document Stores.
-https://docs.haystack.deepset.ai/docs/pipelines
-- [Pipelines](https://docs.haystack.deepset.ai/reference/pipeline-api): Guide to creating and managing pipelines
+- [Pipelines](https://docs.haystack.deepset.ai/docs/pipelines): Guide to creating and managing pipelines
 - [Components](https://docs.haystack.deepset.ai/docs/components): Guide to using ready-made components and creating custom components
 - [Agents](https://docs.haystack.deepset.ai/docs/agents): Guide to agents and tool-calling
 - [Integrations Overview](https://haystack.deepset.ai/integrations): List of all integrations
@@ -27,7 +26,7 @@ https://docs.haystack.deepset.ai/docs/pipelines
 
 ## Optional
 - [Haystack GitHub Repository](https://github.com/deepset-ai/haystack): Source code for Haystack
-- [haystack-experimental GitHub Repository](https://github.com/deepset-ai/haystack): Source code for haystack-experimental features
+- [haystack-experimental GitHub Repository](https://github.com/deepset-ai/haystack-experimental): Source code for haystack-experimental features
 - [haystack-core-integrations GitHub Repository](https://github.com/deepset-ai/haystack-core-integrations): Source code for haystack-core-integrations, such as Amazon Bedrock
 - [hayhooks GitHub Repository](https://github.com/deepset-ai/hayhooks): Source code for Hayhooks, making it easy to deploy and serve Haystack pipelines as REST APIs
 - [Tutorials & Walkthroughs](https://haystack.deepset.ai/tutorials): Collection of tutorials

--- a/layouts/_default/index.txt
+++ b/layouts/_default/index.txt
@@ -1,10 +1,35 @@
-# {{ .Site.Title }}
+# Haystack
 
-> {{ .Site.Params.description }}
+> Haystack is an end-to-end framework for building powerful and production-ready AI applications with Large Language Models (LLMs). It enables developers to create custom pipelines for agents, retrieval-augmented generation (RAG), question answering (QA), semantic document search, and more. Haystack's modular architecture allows integration of various technologies from Amazon Bedrock, Langfuse, Qdrant, Elasticsearch, Pgvector, Hugging Face Transformers, and more.
 
-## Content
-{{ range $type := .Site.Params.front_page_content }}
-### {{ title $type }}
+Key features include:
+- Built-in support for agents and RAG
+- Modular component system for building custom AI workflows, including custom components
+- Flexible pipeline architecture for complex data flows
+- Integration with various LLM providers and open-source projects
+- Support for multiple data modalities beyond text, including image and audio processing
+Installation of Haystack: `pip install haystack-ai`
+Installation of integrations: `pip install <provider>-haystack`, for example `pip install amazon-bedrock-haystack` or `pip install qdrant-haystack`
 
-{{ range (where $.Site.RegularPages "Type" $type) }}- [{{ .Title }}]({{ .Permalink }}index.md): Published {{ .Date.Format "2006-01-02" }}
-{{ end }}{{ end }}
+## Docs
+- [Concepts Overview](https://docs.haystack.deepset.ai/docs/components_overview): Brief introduction to the most important concepts, including Components, Pipelines, Document Stores.
+https://docs.haystack.deepset.ai/docs/pipelines
+- [Pipelines](https://docs.haystack.deepset.ai/reference/pipeline-api): Guide to creating and managing pipelines
+- [Components](https://docs.haystack.deepset.ai/docs/components): Guide to using ready-made components and creating custom components
+- [Agents](https://docs.haystack.deepset.ai/docs/agents): Guide to agents and tool-calling
+- [Integrations Overview](https://haystack.deepset.ai/integrations): List of all integrations
+- [API Reference](https://docs.haystack.deepset.ai/reference/pipeline-api#pipeline): API reference for Pipeline and AsyncPipeline
+
+## Examples
+- [Tutorial on QA Pipeline with RAG](https://haystack.deepset.ai/tutorials/27_first_rag_pipeline): Step-by-step guide to building a QA system with RAG
+- [Tutorial on Tool-Calling Agents](https://haystack.deepset.ai/tutorials/43_building_a_tool_calling_agent): Step-by-step guide to building a tool-calling agent
+- [Tutorial on Preprocessing](https://haystack.deepset.ai/tutorials/30_file_type_preprocessing_index_pipeline): Preprocessing different file types in an indexing pipeline
+
+## Optional
+- [Haystack GitHub Repository](https://github.com/deepset-ai/haystack): Source code for Haystack
+- [haystack-experimental GitHub Repository](https://github.com/deepset-ai/haystack): Source code for haystack-experimental features
+- [haystack-core-integrations GitHub Repository](https://github.com/deepset-ai/haystack-core-integrations): Source code for haystack-core-integrations, such as Amazon Bedrock
+- [hayhooks GitHub Repository](https://github.com/deepset-ai/hayhooks): Source code for Hayhooks, making it easy to deploy and serve Haystack pipelines as REST APIs
+- [Tutorials & Walkthroughs](https://haystack.deepset.ai/tutorials): Collection of tutorials
+- [Cookbook](https://haystack.deepset.ai/cookbook): Collection of use cases
+- [Migration Guide](https://docs.haystack.deepset.ai/docs/migration): Describes differences between Haystack 1.x and Haystack 2.x versions and how to migrate

--- a/layouts/_default/index.txt
+++ b/layouts/_default/index.txt
@@ -32,3 +32,4 @@ Installation of integrations: `pip install <provider>-haystack`, for example `pi
 - [Tutorials & Walkthroughs](https://haystack.deepset.ai/tutorials): Collection of tutorials
 - [Cookbook](https://haystack.deepset.ai/cookbook): Collection of use cases
 - [Migration Guide](https://docs.haystack.deepset.ai/docs/migration): Describes differences between Haystack 1.x and Haystack 2.x versions and how to migrate
+


### PR DESCRIPTION
Go to https://haystack-home-git-llms-txt-deepset-ai.vercel.app/llms.txt
![image](https://github.com/user-attachments/assets/17dbcbe5-41a2-45c8-b0d3-8dbc6094e06c)

Description will be updated in #441 

Possibly, we can list web pages dynamically here. 
Adding `llms.txt` for `docs.haystack.deepset.ai` is not covered with this PR