### PR TITLE
add 1.x tutorial aliases to redirects list

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -143,17 +143,17 @@
       "permanent": true
     },
     {
-      "source": "/tutorials/(02_finetune_a_model_on_your_data|09_dpr_training|10_knowledge_graph|15_tableqa|16_document_classifier_at_index_time|17_audio|18_gpl|19_text_to_image_search_pipeline_with_multimodal_retriever|20_using_haystack_with_rest_api|25_customizing_agent)",
+      "source": "/tutorials/(02_finetune_a_model_on_your_data|fine-tuning-a-model|09_dpr_training|train-dpr|10_knowledge_graph|knowledge-graph|15_tableqa|table-qa|16_document_classifier_at_index_time|doc-class-index|17_audio|audio|18_gpl|gpl|19_text_to_image_search_pipeline_with_multimodal_retriever|multimodal|20_using_haystack_with_rest_api|using-haystack-with-rest-api|25_customizing_agent|customizing-agent)",
       "destination": "/tutorials",
       "permanent": true
     },
     {
-      "source": "/tutorials/(01_basic_qa_pipeline|03_scalable_qa_system|04_faq_style_qa|06_better_retrieval_via_embedding_retrieval|07_rag_generator|11_pipelines|12_lfqa|13_question_generation|21_customizing_promptnode|22_pipeline_with_promptnode)",
+      "source": "/tutorials/(01_basic_qa_pipeline|first-qa-system|without-elasticsearch|03_basic_qa_pipeline_without_elasticsearch|03_scalable_qa_system|existing-faqs|04_faq_style_qa|06_better_retrieval_via_embedding_retrieval|embedding-retrieval|07_rag_generator|11_pipelines|pipelines|12_lfqa|lfqa|13_question_generation|question-generation|21_customizing_promptnode|customizing-promptnode|22_pipeline_with_promptnode|pipeline-with-promptnode|retrieval-augmented-generation)",
       "destination": "/tutorials/27_first_rag_pipeline",
       "permanent": true
     },
     {
-      "source": "/tutorials/08_preprocessing",
+      "source": "/tutorials/(08_preprocessing|preprocessing)",
       "destination": "/tutorials/30_file_type_preprocessing_index_pipeline",
       "permanent": true
     },
@@ -163,27 +163,27 @@
       "permanent": true
     },
     {
-      "source": "/tutorials/26_hybrid_retrieval",
+      "source": "/tutorials/(26_hybrid_retrieval|hybrid-retrieval)",
       "destination": "/tutorials/33_hybrid_retrieval",
       "permanent": true
     },
     {
-      "source": "/tutorials/05_evaluation",
+      "source": "/tutorials/(05_evaluation|evaluation)",
       "destination": "/tutorials/35_evaluating_rag_pipelines",
       "permanent": true
     },
     {
-      "source": "/tutorials/24_building_chat_app",
+      "source": "/tutorials/(24_building_chat_app|building-chat-app)",
       "destination": "/tutorials/40_building_chat_application_with_function_calling",
       "permanent": true
     },
     {
-      "source": "/tutorials/14_query_classifier",
+      "source": "/tutorials/(14_query_classifier|query-classifier)",
       "destination": "/tutorials/41_query_classification_with_transformerstextrouter_and_transformerszeroshottextrouter",
       "permanent": true
     },
     {
-      "source": "/tutorials/23_answering_multihop_questions_with_agents",
+      "source": "/tutorials/(23_answering_multihop_questions_with_agents|multihop-qa-with-agents)",
       "destination": "/tutorials/43_building_a_tool_calling_agent",
       "permanent": true
     }


### PR DESCRIPTION
* Some 1.x tutorials have aliases that cause 404s now such as https://haystack.deepset.ai/tutorials/first-qa-system
* I went over all old aliases in the [1.x eol branch](https://github.com/deepset-ai/haystack-tutorials/blob/1.x-eol/index.toml) to add them to the redirect list