### PR TITLE
feat: allow specifying branch/fork for haystack-integrations clone

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -44,7 +44,8 @@ cp ./haystack-cookbook/notebooks/*.ipynb ./static/downloads
 ls ./static/downloads
 
 rm -rf haystack-integrations
-git clone --depth=1 https://github.com/deepset-ai/haystack-integrations.git
+INTEGRATIONS_BRANCH="${INTEGRATIONS_BRANCH:-main}"
+git clone --depth=1 --branch "$INTEGRATIONS_BRANCH" https://github.com/deepset-ai/haystack-integrations.git
 cp ./haystack-integrations/integrations/*.md ./content/integrations
 
 rm -rf haystack-advent

--- a/build.sh
+++ b/build.sh
@@ -44,8 +44,9 @@ cp ./haystack-cookbook/notebooks/*.ipynb ./static/downloads
 ls ./static/downloads
 
 rm -rf haystack-integrations
+INTEGRATIONS_REPO="${INTEGRATIONS_REPO:-https://github.com/deepset-ai/haystack-integrations.git}"
 INTEGRATIONS_BRANCH="${INTEGRATIONS_BRANCH:-main}"
-git clone --depth=1 --branch "$INTEGRATIONS_BRANCH" https://github.com/deepset-ai/haystack-integrations.git
+git clone --depth=1 --branch "$INTEGRATIONS_BRANCH" "$INTEGRATIONS_REPO"
 cp ./haystack-integrations/integrations/*.md ./content/integrations
 
 rm -rf haystack-advent


### PR DESCRIPTION
Part of https://github.com/deepset-ai/haystack-integrations/issues/465

In order to be able to enable build previews for integrations, we need to allow specifying the fork and/or branch used by a PR.