### PR TITLE
feat: support INTEGRATIONS_BRANCH and INTEGRATIONS_REPO in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -44,7 +44,8 @@ cp ./haystack-cookbook/notebooks/*.ipynb ./static/downloads
 ls ./static/downloads
 
 rm -rf haystack-integrations
-git clone --depth=1 https://github.com/deepset-ai/haystack-integrations.git
+INTEGRATIONS_BRANCH="${INTEGRATIONS_BRANCH:-main}"
+git clone --depth=1 --branch "$INTEGRATIONS_BRANCH" https://github.com/deepset-ai/haystack-integrations.git
 cp ./haystack-integrations/integrations/*.md ./content/integrations
 
 rm -rf haystack-advent

--- a/build.sh
+++ b/build.sh
@@ -44,8 +44,9 @@ cp ./haystack-cookbook/notebooks/*.ipynb ./static/downloads
 ls ./static/downloads
 
 rm -rf haystack-integrations
+INTEGRATIONS_REPO="${INTEGRATIONS_REPO:-https://github.com/deepset-ai/haystack-integrations.git}"
 INTEGRATIONS_BRANCH="${INTEGRATIONS_BRANCH:-main}"
-git clone --depth=1 --branch "$INTEGRATIONS_BRANCH" https://github.com/deepset-ai/haystack-integrations.git
+git clone --depth=1 --branch "$INTEGRATIONS_BRANCH" "$INTEGRATIONS_REPO"
 cp ./haystack-integrations/integrations/*.md ./content/integrations
 
 rm -rf haystack-advent


### PR DESCRIPTION
Allows Vercel preview builds to clone a specific branch (and optionally fork) of `haystack-integrations` instead of always using `main`.

Two new env vars in `build.sh`:
- `INTEGRATIONS_REPO` — clone URL (default: `deepset-ai/haystack-integrations`)  
- `INTEGRATIONS_BRANCH` — branch to clone (default: `main`)

Used by the preview workflow in `haystack-integrations` to generate per-PR previews.